### PR TITLE
Fix typing inconsistencies with union

### DIFF
--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -132,7 +132,7 @@
 
 'use strict';
 
-import {Buffer} from 'buffer';
+import { Buffer } from 'buffer';
 
 /* Convenience type alias for objects.
  *
@@ -1439,8 +1439,8 @@ export class Union extends Layout<LayoutObject> {
 
   constructor(
       discr: Layout<LayoutObject> | UnionDiscriminator,
-      defaultLayout: Layout<LayoutObject> | null,
-      property: string
+      defaultLayout?: Layout<LayoutObject> | null,
+      property?: string
   ) {
     let discriminator: UnionDiscriminator;
     if ((discr instanceof UInt)
@@ -2624,11 +2624,11 @@ export const seq = (<T>(elementLayout: Layout<T>, count: number | ExternalLayout
 
 /** Factory for {@link Union} values. */
 export const union = ((discr: Layout<LayoutObject> | UnionDiscriminator,
-                       defaultLayout: Layout<LayoutObject> | null, property: string): Union =>
+                       defaultLayout?: Layout<LayoutObject> | null, property?: string): Union =>
     new Union(discr, defaultLayout, property));
 
 /** Factory for {@link UnionLayoutDiscriminator} values. */
-export const unionLayoutDiscriminator = ((layout: ExternalLayout, property: string): UnionLayoutDiscriminator =>
+export const unionLayoutDiscriminator = ((layout: ExternalLayout, property?: string): UnionLayoutDiscriminator =>
     new UnionLayoutDiscriminator(layout, property));
 
 /** Factory for {@link Blob} values. */

--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -1438,7 +1438,7 @@ export class Union extends Layout<LayoutObject> {
   configGetSourceVariant: (getSourceVariant: (src: LayoutObject) => VariantLayout | undefined) => void;
 
   constructor(
-      discr: Layout<LayoutObject> | UnionDiscriminator,
+      discr: UInt | UIntBE | ExternalLayout | UnionDiscriminator,
       defaultLayout?: Layout<LayoutObject> | null,
       property?: string
   ) {
@@ -2623,7 +2623,7 @@ export const seq = (<T>(elementLayout: Layout<T>, count: number | ExternalLayout
     new Sequence<T>(elementLayout, count, property));
 
 /** Factory for {@link Union} values. */
-export const union = ((discr: Layout<LayoutObject> | UnionDiscriminator,
+export const union = ((discr: UInt | UIntBE | ExternalLayout | UnionDiscriminator,
                        defaultLayout?: Layout<LayoutObject> | null, property?: string): Union =>
     new Union(discr, defaultLayout, property));
 


### PR DESCRIPTION
The typing for the `union` and `unionLayoutDiscriminator` functions are inconsistent with the rest of the API and more restrictive than that of `buffer-layout`.